### PR TITLE
Make compatible with clang

### DIFF
--- a/compiler/GrcErrorList.cpp
+++ b/compiler/GrcErrorList.cpp
@@ -294,7 +294,7 @@ void GrcErrorList::WriteErrorsToStream(std::ostream& strmOut,
 void WriteTableDescriptionString(std::ostream& strmOut, TableId ti)
 {
     uint32 nTag = TtfUtil::TableIdTag(ti);
-    char csTagStr[] = {' ', nTag >> 24, (nTag >> 16) & 0xff, (nTag >> 8) & 0xff, nTag & 0xff, ':', 0};
+    char csTagStr[] = {' ', (char)(nTag >> 24), (char)(nTag >> 16), (char)(nTag >> 8), (char)nTag, ':', 0};
     double dCompressionRatio = g_cman.CompressionRatio(ti);
     strmOut << csTagStr << VersionString(g_cman.TableVersion(ti));
 


### PR DESCRIPTION
clang++ 4.0 through 6.0 with C++11 give the following error for each of the array's elements:
GrcErrorList.cpp:297:49: error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'char' in initializer list [-Wc++11-narrowing]

This commit fixes this.

There are no other errors with clang.