### PR TITLE
Make the Debian watch file scan GitHub

### DIFF
--- a/debian/watch
+++ b/debian/watch
@@ -1,2 +1,3 @@
-version=3
-http://sf.net/silgraphite/grcompiler-(.+)\.tar\.gz
+version=4
+opts=filenamemangle=s/.+\/v?(\d\S+)\.tar\.gz/grcompiler-$1\.tar\.gz/ \
+  https://github.com/silnrsi/grcompiler/tags .*/v?(\d\S+)\.tar\.gz


### PR DESCRIPTION
Please also make versions 5.0, 5.0.1 and 5.0.2 available as GitHub releases.