### PR TITLE
Issue 11: Please use pkg-config to detect icu

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,7 @@ AC_PROG_CPP
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 AC_PROG_RANLIB
+PKG_PROG_PKG_CONFIG
 
 AC_PATH_PROG(LSB_RELEASE, lsb_release, no)
 
@@ -44,21 +45,14 @@ if test "$DOCBOOK2MAN" = no; then
     AC_MSG_FAILURE([Could not find a program to process XML man pages])
 fi
 
-# ICU configuration
-AC_ARG_VAR(ICU_CONFIG, [Check for ICU configuration helper])
-AC_CHECK_PROGS(ICU_CONFIG, icu-config, no)
+# Check packages needed
+PKG_CHECK_MODULES([ICU], [icu-i18n > 3.6])
+LIBS="$LIBS $ICU_LIBS"
 
 # Set default language for tests
 
 AC_LANG(C++)
-
 # Checks for libraries.
-
-if test "$ICU_CONFIG" == no; then
-    AC_MSG_FAILURE([Could not find icu-config])
-else
-    LIBS="$LIBS `$ICU_CONFIG --ldflags-libsonly`"
-fi
 
 # Checks for header files.
 # need to check for icu .h files as in unicode/uchar.h

--- a/test/GrcRegressionTest/regtest
+++ b/test/GrcRegressionTest/regtest
@@ -18,7 +18,7 @@ storing log info in logfile and exiting with the number of errors
   -d|--dir=dir              Use dir for intermediate test files
   -g|--compiler=grcompiler  command to use to run grcompiler [grcompiler]
   -h|--help                 print this help and exit
-  -i|--icu=version          Gives icu version or uses icu-config * 10 to guess
+  -i|--icu=version          Gives icu version or uses pkg-config to determine
   -k|--keep                 keep temporary files
   -o|--output= logfile      file to log to [regtest.log]
   -p|--preprocessor=gdlpp   command to run the gdlpp []
@@ -39,7 +39,7 @@ my ($dir) = $ARGV[0] || '.';
 my (@fonts) = sort glob("$dir/*Input.ttf");
 my ($outf) = IO::File->new("> $opts{output}") || die "Can't create $opts{output}";
 my ($f, $errors);
-$opts{icu} ||= `icu-config --version` * 10;
+$opts{icu} ||= `pkg-config --modversion icu-i18n`;
 my (@icudirs) = reverse sort map {s/^.*?(\d+)$/$1/o; $_} glob("$dir/icu*");
 
 foreach $f (@fonts)

--- a/test/GrcRegressionTest/regtest
+++ b/test/GrcRegressionTest/regtest
@@ -5,7 +5,7 @@ use Getopt::Long;
 use File::Compare;
 
 my (%opts);
-GetOptions(\%opts, 'dir|d=s', 'compiler|g=s', 'help|h|?', 'icu|i', 'keep|k', 'output|o=s', 'preprocessor|p=s', 'verbose|v', 'testengine|r=s', 'version=i', 'warning|w=i@');
+GetOptions(\%opts, 'dir|d=s', 'compiler|g=s', 'help|h|?', 'icu|i=f', 'keep|k', 'output|o=s', 'preprocessor|p=s', 'verbose|v', 'testengine|r=s', 'version=i', 'warning|w=i@');
 
 if ($opts{help})
 {
@@ -18,7 +18,7 @@ storing log info in logfile and exiting with the number of errors
   -d|--dir=dir              Use dir for intermediate test files
   -g|--compiler=grcompiler  command to use to run grcompiler [grcompiler]
   -h|--help                 print this help and exit
-  -i|--icu                  Gives icu version or uses icu-config * 10 to guess
+  -i|--icu=version          Gives icu version or uses icu-config * 10 to guess
   -k|--keep                 keep temporary files
   -o|--output= logfile      file to log to [regtest.log]
   -p|--preprocessor=gdlpp   command to run the gdlpp []


### PR DESCRIPTION
This patchset:

- Modifies `regtest` so the `-i` and `--icu` options actually accept an argument.
- Uses pkg-config to detect icu.

Happy to discuss and/or modify.