### PR TITLE
Feature nuget dependecies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,22 @@ if (NOT CMAKE_BUILD_TYPE)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE Release)
 endif()
 
+if  (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+    add_definitions(-D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -DWIN32 -D_WINDOWS)
+
+    find_program(NUGET nuget)
+    if(NOT NUGET AND WIN32)
+        message(FATAL "CMake could not find the nuget command line tool. Please install it!")
+    else()
+        # Copy the Nuget config file from source location to the CMake build directory.
+        configure_file(packages.config.in packages.config COPYONLY)
+        # Run Nuget using the .config file to install any missing dependencies to the build directory.
+        execute_process(
+            COMMAND ${NUGET} restore packages.config -SolutionDirectory ${CMAKE_BINARY_DIR}
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+    endif()
+endif()
+
 add_subdirectory(doc)
 add_subdirectory(preprocessor)
 add_subdirectory(compiler)

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -1,12 +1,32 @@
 project(compiler)
 
-find_package(ICU COMPONENTS uc i18n data REQUIRED)
+if (NUGET AND NOT ICU_ROOT)
+    file(GLOB ICU_ROOT "${CMAKE_BINARY_DIR}/packages/icu4c*")
+    set(ICU_ROOT ${ICU_ROOT}/build/native)
+    message("PATH=${ICU_ROOT}/lib/${CMAKE_VS_PLATFORM_NAME}/${CMAKE_BUILD_TYPE}")
+    find_library(ICU_I18N_LIBRARY 
+        NAMES icuin icui18n 
+        PATHS "${ICU_ROOT}/lib/${CMAKE_VS_PLATFORM_NAME}/${CMAKE_BUILD_TYPE}"
+        NO_DEFAULT_PATH)
+    find_library(ICU_UC_LIBRARY
+        NAMES icuuc
+        PATHS "${ICU_ROOT}/lib/${CMAKE_VS_PLATFORM_NAME}/${CMAKE_BUILD_TYPE}"
+        NO_DEFAULT_PATH)
+    find_path(ICU_INCLUDE_DIR
+        NAMES "unicode/utypes.h"
+        HINTS ${ICU_ROOT}
+        PATH_SUFFIXES include
+        DOC "ICU include directory")
+else()
+	find_package(ICU REQUIRED COMPONENTS uc i18n)
+endif()
+
 
 add_subdirectory(Generic)
 add_subdirectory(Grammar)
 add_subdirectory(LZ4)
 
-include_directories(Generic Grammar LZ4)
+include_directories(Generic Grammar LZ4 ${ICU_INCLUDE_DIR})
 
 add_library(TtfUtil OBJECT TtfUtil.cpp)
 
@@ -38,7 +58,13 @@ add_executable(grcompiler
     PostParser.cpp 
     $<TARGET_OBJECTS:TtfUtil>
     main.cpp)
-target_link_libraries(grcompiler ${ICU_LIBRARIES} generic parser lz4)
+target_link_libraries(grcompiler ${ICU_I18N_LIBRARY} ${ICU_UC_LIBRARY} generic parser lz4)
+
+if  (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+    set_target_properties(grcompiler PROPERTIES
+        COMPILE_OPTIONS "/Zc:wchar_t-;/W3;/GR;/EHsc"
+        COMPILE_DEFINITIONS "_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINDOWS;WIN32")
+endif()
 
 install(TARGETS grcompiler RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES stddef.gdh DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME})

--- a/compiler/Generic/GrPlatform.h
+++ b/compiler/Generic/GrPlatform.h
@@ -199,8 +199,9 @@ unsigned short MultiByteToWideChar(unsigned long code_page, unsigned long,
 using namespace gr;
 #endif
 
+#if !defined(_WIN32)
 // Don't put this in the gr namespace; it confuses the compiler:
 char * itoa(int value, char *string, int radix);
-
+#endif
 
 #endif

--- a/packages.config.in
+++ b/packages.config.in
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="icu4c.v140" version="59.1.1" allowedVersions="[36,]"/>
+</packages>

--- a/test/GrcRegressionTest/CMakeLists.txt
+++ b/test/GrcRegressionTest/CMakeLists.txt
@@ -8,5 +8,11 @@ add_executable(GrcRegressionTest
     GrcRtFileFont.cpp 
     GrcRegressionTest.cpp 
     $<TARGET_OBJECTS:TtfUtil>)
+target_link_libraries(GrcRegressionTest generic)
 
-add_test(NAME check-local COMMAND ${PROJECT_SOURCE_DIR}/regtest -k -v -g $<TARGET_FILE:grcompiler> -p $<TARGET_FILE:gdlpp> -r $<TARGET_FILE:GrcRegressionTest> -d ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/fonts)
+find_program(PERL perl)
+if (PERL)
+    add_test(NAME check-local COMMAND ${PERL} ${PROJECT_SOURCE_DIR}/regtest -k -v -g $<TARGET_FILE:grcompiler> -p $<TARGET_FILE:gdlpp> -r $<TARGET_FILE:GrcRegressionTest> -d ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/fonts)
+else()
+    message("Perl interpreter not found cannot run tests.")
+endif()


### PR DESCRIPTION
Add support for using nuget to fetch ICU dependencies and build using those.

This can be overridden using by setting the ICU_ROOT cmake variable if you have a pre existing built ICU tree already.