### PR TITLE
FTBFS: Fix std::isdigit calls to work on Windows

### DIFF
--- a/compiler/OutputToFont.cpp
+++ b/compiler/OutputToFont.cpp
@@ -909,7 +909,7 @@ bool GrcManager::BuildFontNames(bool f8bitTable,
 	{ 	// Preserve the date from the input ttf if it's available
 		std::u16string date_field = unique_name.substr(n + 1);
 		std::u16string decade = date_field.substr(date_field.size() - 2);
-		if (std::isdigit(decade[0]) && std::isdigit(decade[1]))
+		if (std::isdigit(int(decade[0])) && std::isdigit(int(decade[1])))
 		{
 			unique_name = vendor + u": " + full_name + u": " + date_field;
 		}

--- a/compiler/OutputToFont.cpp
+++ b/compiler/OutputToFont.cpp
@@ -907,9 +907,15 @@ bool GrcManager::BuildFontNames(bool f8bitTable,
 	std::string::size_type n = unique_name.rfind(u":");
 	if (n != std::string::npos)
 	{ 	// Preserve the date from the input ttf if it's available
+		std::locale const loc; // Use the system default or "C" locale.
+		// Use the line below instead line of the one above for ASCII only digits.
+		// std::locale const & loc = std::locale::classic(); 
 		std::u16string date_field = unique_name.substr(n + 1);
 		std::u16string decade = date_field.substr(date_field.size() - 2);
-		if (std::isdigit(int(decade[0])) && std::isdigit(int(decade[1])))
+		// These need to be cast to char or wchar_t, as there are no stdlib
+		// supplied std::ctype<char16_t> facets. wchar_t expands the recognised
+		// digits up to the BMP, not just ANSI (where supported by the locale).
+		if (std::isdigit(wchar_t(decade[0]),loc) && std::isdigit(wchar_t(decade[1]),loc))
 		{
 			unique_name = vendor + u": " + full_name + u": " + date_field;
 		}


### PR DESCRIPTION
_Some_ versions of MSVC++ don't recognise the standard C `std::isdigit()` or `std::iswdigit()` functions, even when the `<cctypes>` header is included.
This patch uses the C++ stdlib version. We have to cast the `char16_t` to either `wchar_t` or `char_t` as there is no in-built support for ctype facets of type `char16_t`. I picked `wchar_t` to permit us to recognise any digit in the BMP (if the system locale supports it), however if we want just 0-9 we can change the cast type to `char` in the `std::isdigit()` calls and replace the locale declaration with the `std::locale::classic()` line, as mentioned in the comments.