### PR TITLE
Add missing WORDS_BIGENDIAN definition

### DIFF
--- a/compiler/Generic/CMakeLists.txt
+++ b/compiler/Generic/CMakeLists.txt
@@ -4,6 +4,7 @@ if  (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 endif()
 
 add_library(generic STATIC Platform.cpp)
+target_compile_definitions(generic PUBLIC $<${BIGENDIAN_SYSTEM}:WORDS_BIGENDIAN>)
 add_definitions(-DGR_NAMESPACE)
 
 if (Iconv_FOUND)


### PR DESCRIPTION
Fixes #45 Test failures on big endian architectures